### PR TITLE
add: day wise log split and log files management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
+# Project Implementation Logs
+logFiles
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/logger/logger.js
+++ b/logger/logger.js
@@ -1,4 +1,5 @@
 const winston = require('winston');
+require('winston-daily-rotate-file');
 
 // decide on log level based on environment [dev / qa / staging / prod]
 const environment = 'dev'; // to be added from process.env
@@ -12,9 +13,8 @@ let location = 'local runtime'
 
 // output file
 let logDir = './logFiles/';
-let date = new Date().toISOString().split('T')[0];
-let errorFilePath = logDir + date + '-' + 'error.log';
-let comboFilePath = logDir + date + '-' + 'combined.log';
+let errorFileName = 'error.log';
+let comboFileName = 'combined.log';
 
 
 /*
@@ -37,9 +37,16 @@ const log = winston.createLogger({
     ),
     defaultMeta: { project: project, repo: repo, type: type, location: location },
     transports: [
-        new winston.transports.File({ filename: errorFilePath, level: 'error' }),
-        new winston.transports.File({ filename: comboFilePath }),
-        // new winston.transports.Console({ format: winston.format.simple() })
+        new winston.transports.DailyRotateFile({
+            level: 'error',
+            filename: `${logDir}%DATE%-${errorFileName}`,
+            datePattern: 'YYYY-MM-DD'
+        }),
+        new winston.transports.DailyRotateFile({
+            filename: `${logDir}%DATE%-${comboFileName}`,
+            datePattern: 'YYYY-MM-DD'
+        }),
+        // new winston.transports.Console({ format: winston.format.simple() }),
         new winston.transports.Console({ format: winston.format.printf(info => `[${info.timestamp}] (${info.level}): ${info.repo} > ${info.category} > ${info.subcategory} - ${info.message} ${info.stack ? '\n' + info.stack : ''}`) })
     ]
 });

--- a/logger/logger.js
+++ b/logger/logger.js
@@ -40,11 +40,17 @@ const log = winston.createLogger({
         new winston.transports.DailyRotateFile({
             level: 'error',
             filename: `${logDir}%DATE%-${errorFileName}`,
-            datePattern: 'YYYY-MM-DD'
+            datePattern: 'YYYY-MM-DD',
+            zippedArchive: true,
+            maxSize: null,
+            maxFiles: '30d'
         }),
         new winston.transports.DailyRotateFile({
             filename: `${logDir}%DATE%-${comboFileName}`,
-            datePattern: 'YYYY-MM-DD'
+            datePattern: 'YYYY-MM-DD',
+            zippedArchive: true,
+            maxSize: null,
+            maxFiles: '30d'
         }),
         // new winston.transports.Console({ format: winston.format.simple() }),
         new winston.transports.Console({ format: winston.format.printf(info => `[${info.timestamp}] (${info.level}): ${info.repo} > ${info.category} > ${info.subcategory} - ${info.message} ${info.stack ? '\n' + info.stack : ''}`) })

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,14 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
     },
+    "file-stream-rotator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
+      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
+      "requires": {
+        "moment": "^2.29.1"
+      }
+    },
     "fn.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
@@ -117,10 +125,20 @@
         "triple-beam": "^1.3.0"
       }
     },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+    },
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
     },
     "one-time": {
       "version": "1.0.0",
@@ -202,6 +220,17 @@
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
         "winston-transport": "^4.5.0"
+      }
+    },
+    "winston-daily-rotate-file": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-4.7.1.tgz",
+      "integrity": "sha512-7LGPiYGBPNyGHLn9z33i96zx/bd71pjBn9tqQzO3I4Tayv94WPmBNwKC7CO1wPHdP9uvu+Md/1nr6VSH9h0iaA==",
+      "requires": {
+        "file-stream-rotator": "^0.6.1",
+        "object-hash": "^2.0.1",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
       }
     },
     "winston-transport": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/mratanusarkar/NodeJS-Logging-Mechanism#readme",
   "dependencies": {
-    "winston": "^3.8.2"
+    "winston": "^3.8.2",
+    "winston-daily-rotate-file": "^4.7.1"
   }
 }


### PR DESCRIPTION
Improvisation of the existing implementation. This will enable the logs to be split day-wise and also manage the files and have some sort of retention policy or auto-delete after a certain number of days.

This fixes issue: #2 

Topic Breakdown:

- [x] fix the issue of logs not getting split into date-wise logs
- [x] implement log management (so that the log files don't overflow taking up memory)
- [x] implement an auto-delete or auto-archival of the logs
- [x] implement a retention policy

TODO (for future reference):

- make the implementation values dynamic and configurable (remove hardcoded values)
- make the existing metadata dynamic and configurable (remove hardcoded values)