### PR TITLE
add: action listeners for log-rotate

### DIFF
--- a/logger/logger.js
+++ b/logger/logger.js
@@ -44,14 +44,40 @@ const log = winston.createLogger({
             zippedArchive: true,
             maxSize: null,
             maxFiles: '30d'
+        }).on('new', function (newFilename) {
+            console.log("> on new:", newFilename);
+            // do something, or perform some actions...
+        }).on('rotate', function (oldFilename, newFilename) {
+            console.log("> on rotate:", oldFilename, newFilename);
+            // do something, or perform some actions...
+        }).on('archive', function (zipFilename) {
+            console.log("> on archive:", zipFilename);
+            // do something, or perform some actions...
+        }).on('logRemoved', function (removedFilename) {
+            console.log("> on logRemoved:", removedFilename);
+            // do something, or perform some actions...
         }),
+
         new winston.transports.DailyRotateFile({
             filename: `${logDir}%DATE%-${comboFileName}`,
             datePattern: 'YYYY-MM-DD',
             zippedArchive: true,
             maxSize: null,
             maxFiles: '30d'
+        }).on('new', function (newFilename) {
+            console.log("> on new:", newFilename);
+            // do something, or perform some actions...
+        }).on('rotate', function (oldFilename, newFilename) {
+            console.log("> on rotate:", oldFilename, newFilename);
+            // do something, or perform some actions...
+        }).on('archive', function (zipFilename) {
+            console.log("> on archive:", zipFilename);
+            // do something, or perform some actions...
+        }).on('logRemoved', function (removedFilename) {
+            console.log("> on logRemoved:", removedFilename);
+            // do something, or perform some actions...
         }),
+
         // new winston.transports.Console({ format: winston.format.simple() }),
         new winston.transports.Console({ format: winston.format.printf(info => `[${info.timestamp}] (${info.level}): ${info.repo} > ${info.category} > ${info.subcategory} - ${info.message} ${info.stack ? '\n' + info.stack : ''}`) })
     ]


### PR DESCRIPTION
add action listeners based on the following events emitted by [winston-daily-log-rotate](https://www.npmjs.com/package/winston-daily-rotate-file):

- new
- rotate
- archive
- log removed

In future, we can plan to add custom functions to read and transport the logs so somewhere, or upload to cloud, perform some actions and activities based on these emitted events. The possibilities are endless!